### PR TITLE
feat: add badge for scheduled unpublish actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ All notable changes to this project will be documented in this file. See
 
 - make sanity config a function so the current Space is respected ([#13](https://github.com/sanity-io/sanity-plugin-scheduled-publishing/issues/13)) ([e21034c](https://github.com/sanity-io/sanity-plugin-scheduled-publishing/commit/e21034cc85036215601dced21ffe158212b6f252))
 
-# Changelog
-
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
-
 ### [0.1.10](https://github.com/sanity-io/sanity-plugin-scheduled-publishing/compare/v0.1.9...v0.1.10) (2022-07-04)
 
 ### Bug Fixes

--- a/src/components/documentWrapper/ScheduleBanner.tsx
+++ b/src/components/documentWrapper/ScheduleBanner.tsx
@@ -19,7 +19,7 @@ export function ScheduleBanner(props: Props) {
   const {id, markers, type} = props
   const publishedId = usePublishedId(id)
   const {hasError} = useValidationState(markers)
-  const formattedDateTime = useNextSchedule(publishedId)
+  const {formattedDateTime, action} = useNextSchedule(publishedId)
 
   if (!formattedDateTime) {
     return null
@@ -33,12 +33,14 @@ export function ScheduleBanner(props: Props) {
         paddingX={3}
         radius={1}
         shadow={1}
-        tone={hasError ? 'critical' : 'primary'}
+        tone={hasError ? 'critical' : `${action === 'publish' ? 'primary' : 'caution'}`}
       >
         <Stack space={2}>
           <Flex>
             <Badge fontSize={1} mode="outline" padding={2} style={{flexShrink: 0}}>
-              {hasError ? 'Scheduled (with errors)' : 'Scheduled'}
+              {hasError
+                ? 'Scheduled (with errors)'
+                : `${action === 'publish' ? 'Scheduled' : `Scheduled Unpublish`}`}
             </Badge>
           </Flex>
 
@@ -53,7 +55,9 @@ export function ScheduleBanner(props: Props) {
               </Box>
             )}
             <Text muted size={1}>
-              {hasError ? 'Publishing with errors on' : 'Scheduled to publish on'}{' '}
+              {hasError
+                ? 'Publishing with errors on'
+                : `Scheduled to ${action === 'publish' ? `Publish` : `Unpublish`} on`}{' '}
               <span style={{fontWeight: 500}}>{formattedDateTime}</span> (local time)
             </Text>
           </Flex>
@@ -63,15 +67,21 @@ export function ScheduleBanner(props: Props) {
   )
 }
 
-function useNextSchedule(id: string) {
+function useNextSchedule(id: string): {
+  formattedDateTime?: string
+  action?: string
+} {
   const {schedules} = usePollSchedules({documentId: id, state: 'scheduled'})
 
   return useMemo(() => {
     const upcomingSchedule = schedules?.[0]
 
     if (!upcomingSchedule || !upcomingSchedule.executeAt) {
-      return undefined
+      return {}
     }
-    return format(new Date(upcomingSchedule.executeAt), DATE_FORMAT.LARGE)
+    return {
+      formattedDateTime: format(new Date(upcomingSchedule.executeAt), DATE_FORMAT.LARGE),
+      action: upcomingSchedule.action,
+    }
   }, [schedules])
 }

--- a/src/components/documentWrapper/ScheduleBanner.tsx
+++ b/src/components/documentWrapper/ScheduleBanner.tsx
@@ -1,87 +1,74 @@
 import {CalendarIcon} from '@sanity/icons'
-import {Marker, SchemaType} from '@sanity/types'
-import {Badge, Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import type {Marker} from '@sanity/types'
+import {Badge, Box, Card, Flex, Inline, Stack, Text} from '@sanity/ui'
 import {format} from 'date-fns'
-import React, {useMemo} from 'react'
-import {DATE_FORMAT} from '../../constants'
+import React from 'react'
+import {DATE_FORMAT, DOCUMENT_HAS_ERRORS_TEXT} from '../../constants'
 import usePollSchedules from '../../hooks/usePollSchedules'
 import {usePublishedId} from '../../hooks/usePublishedId'
 import {useValidationState} from '../../utils/validationUtils'
-import {ValidationInfo} from '../validation/ValidationInfo'
 
 interface Props {
   id: string
   markers: Marker[]
-  type: SchemaType
 }
 
 export function ScheduleBanner(props: Props) {
-  const {id, markers, type} = props
+  const {id, markers} = props
   const publishedId = usePublishedId(id)
   const {hasError} = useValidationState(markers)
-  const {formattedDateTime, action} = useNextSchedule(publishedId)
 
-  if (!formattedDateTime) {
+  const {schedules} = usePollSchedules({documentId: publishedId, state: 'scheduled'})
+
+  const hasSchedules = schedules.length > 0
+  if (!hasSchedules) {
     return null
   }
 
   return (
     <Box marginBottom={4}>
-      <Card
-        paddingBottom={2}
-        paddingTop={3}
-        paddingX={3}
-        radius={1}
-        shadow={1}
-        tone={hasError ? 'critical' : `${action === 'publish' ? 'primary' : 'caution'}`}
-      >
+      <Card padding={3} radius={1} shadow={1} tone={hasError ? 'critical' : 'primary'}>
         <Stack space={2}>
-          <Flex>
-            <Badge fontSize={1} mode="outline" padding={2} style={{flexShrink: 0}}>
-              {hasError
-                ? 'Scheduled (with errors)'
-                : `${action === 'publish' ? 'Scheduled' : `Scheduled Unpublish`}`}
-            </Badge>
-          </Flex>
-
-          <Flex align="center" gap={1}>
-            {hasError ? (
-              <ValidationInfo markers={markers} type={type} documentId={publishedId} />
-            ) : (
-              <Box padding={3}>
-                <Text muted>
-                  <CalendarIcon />
-                </Text>
-              </Box>
-            )}
+          <Flex align="center" gap={3} marginBottom={1} padding={1}>
             <Text muted size={1}>
-              {hasError
-                ? 'Publishing with errors on'
-                : `Scheduled to ${action === 'publish' ? `Publish` : `Unpublish`} on`}{' '}
-              <span style={{fontWeight: 500}}>{formattedDateTime}</span> (local time)
+              <CalendarIcon />
+            </Text>
+            <Text muted size={1}>
+              <span style={{fontWeight: 600}}>Upcoming schedule</span> (local time)
             </Text>
           </Flex>
+
+          <Stack space={2}>
+            {schedules.map((schedule) => {
+              if (!schedule.executeAt) {
+                return null
+              }
+              const formattedDateTime = format(new Date(schedule.executeAt), DATE_FORMAT.LARGE)
+              return (
+                <Inline key={schedule.id} space={2}>
+                  <Text muted size={1}>
+                    {formattedDateTime}
+                  </Text>
+                  {/* HACK: Hide non unpublish schedules to maintain layout */}
+                  <Flex style={{opacity: schedule.action === 'unpublish' ? 1 : 0}}>
+                    <Badge fontSize={0} mode="outline">
+                      {schedule.action}
+                    </Badge>
+                  </Flex>
+                </Inline>
+              )
+            })}
+          </Stack>
+
+          {hasError && (
+            <Box marginTop={3}>
+              <Text muted size={1} weight="regular">
+                {DOCUMENT_HAS_ERRORS_TEXT}
+              </Text>
+            </Box>
+          )}
         </Stack>
       </Card>
     </Box>
   )
-}
-
-function useNextSchedule(id: string): {
-  formattedDateTime?: string
-  action?: string
-} {
-  const {schedules} = usePollSchedules({documentId: id, state: 'scheduled'})
-
-  return useMemo(() => {
-    const upcomingSchedule = schedules?.[0]
-
-    if (!upcomingSchedule || !upcomingSchedule.executeAt) {
-      return {}
-    }
-    return {
-      formattedDateTime: format(new Date(upcomingSchedule.executeAt), DATE_FORMAT.LARGE),
-      action: upcomingSchedule.action,
-    }
-  }, [schedules])
 }

--- a/src/components/documentWrapper/ScheduledDocumentInput.tsx
+++ b/src/components/documentWrapper/ScheduledDocumentInput.tsx
@@ -20,7 +20,7 @@ export const ScheduledDocumentInput = forwardRef(function ScheduledDocumentInput
 
   return (
     <>
-      {value?._id ? <ScheduleBanner id={value._id} markers={markers} type={type} /> : null}
+      {value?._id ? <ScheduleBanner id={value._id} markers={markers} /> : null}
       <NestedFormBuilder {...props} ref={ref} type={type} />
     </>
   )

--- a/src/components/scheduleItem/PreviewWrapper.tsx
+++ b/src/components/scheduleItem/PreviewWrapper.tsx
@@ -2,10 +2,14 @@ import {SchemaType} from '@sanity/types'
 import {Badge, Box, Card, Flex, Inline, Stack, Text} from '@sanity/ui'
 import {SanityDefaultPreview} from 'part:@sanity/base/preview'
 import React, {ElementType, ReactNode, useState} from 'react'
-import {DOCUMENT_HAS_ERRORS_TEXT, DOCUMENT_HAS_WARNINGS_TEXT} from '../../constants'
+import {
+  DOCUMENT_HAS_ERRORS_TEXT,
+  DOCUMENT_HAS_WARNINGS_TEXT,
+  SCHEDULE_ACTION_DICTIONARY,
+} from '../../constants'
 import useTimeZone from '../../hooks/useTimeZone'
-import {Schedule} from '../../types'
-import {PaneItemPreviewState} from '../../utils/paneItemHelpers'
+import type {Schedule} from '../../types'
+import type {PaneItemPreviewState} from '../../utils/paneItemHelpers'
 import {getLastExecuteDate} from '../../utils/scheduleUtils'
 import {EMPTY_VALIDATION_STATUS, useValidationState} from '../../utils/validationUtils'
 import {ValidateScheduleDoc} from '../validation/SchedulesValidation'
@@ -64,56 +68,49 @@ const PreviewWrapper = (props: Props) => {
           tabIndex={0}
           tone={validationTone}
         >
-          <Flex align="center" justify="space-between">
+          <Flex align="center" gap={3} justify="flex-start" paddingLeft={children ? 0 : [1, 2]}>
             {children && <Box style={{flexBasis: 'auto', flexGrow: 1}}>{children}</Box>}
-            {schedule.action === 'unpublish' ? (
-              <Badge mode="outline" tone="caution" fontSize={0}>
-                Unpublish
-              </Badge>
-            ) : null}
+
+            {/* Badge */}
+            {schedule.action === 'unpublish' && (
+              <Flex style={{flexShrink: 0}}>
+                <Badge
+                  fontSize={0}
+                  mode="outline"
+                  tone={SCHEDULE_ACTION_DICTIONARY[schedule.action].badgeTone}
+                >
+                  {schedule.action}
+                </Badge>
+              </Flex>
+            )}
+
             {/* Schedule date */}
-            <>
-              <Box
-                display={['block', 'none']}
-                marginLeft={children ? [3, 3, 4] : 2}
-                style={{
-                  flexShrink: 0,
-                  width: '90px',
-                }}
-              >
-                <Stack space={2}>
-                  {scheduleDate ? (
-                    <>
-                      <Text size={1}>
-                        {formatDateTz({date: scheduleDate, format: 'dd/MM/yyyy'})}
-                      </Text>
-                      <Text size={1}>{formatDateTz({date: scheduleDate, format: 'p'})}</Text>
-                    </>
-                  ) : (
-                    <Text muted size={1}>
-                      <em>No date specified</em>
-                    </Text>
-                  )}
-                </Stack>
-              </Box>
-              <Box
-                display={['none', 'block']}
-                marginLeft={children ? [3, 3, 4] : 2}
-                style={{
-                  flexShrink: 0,
-                  maxWidth: '250px',
-                  width: children ? '35%' : 'auto',
-                }}
-              >
+            <Box display={['block', 'none']} style={{flexShrink: 0, width: '90px'}}>
+              <Stack space={2}>
                 {scheduleDate ? (
-                  <DateWithTooltip date={scheduleDate} useElementQueries={useElementQueries} />
+                  <>
+                    <Text size={1}>{formatDateTz({date: scheduleDate, format: 'dd/MM/yyyy'})}</Text>
+                    <Text size={1}>{formatDateTz({date: scheduleDate, format: 'p'})}</Text>
+                  </>
                 ) : (
                   <Text muted size={1}>
                     <em>No date specified</em>
                   </Text>
                 )}
-              </Box>
-            </>
+              </Stack>
+            </Box>
+            <Box
+              display={['none', 'block']}
+              style={{flexShrink: 0, maxWidth: '250px', width: children ? '35%' : 'auto'}}
+            >
+              {scheduleDate ? (
+                <DateWithTooltip date={scheduleDate} useElementQueries={useElementQueries} />
+              ) : (
+                <Text muted size={1}>
+                  <em>No date specified</em>
+                </Text>
+              )}
+            </Box>
 
             {/* HACK: render invisible preview wrapper when no children are provided to ensure consistent height */}
             {!children && (
@@ -122,14 +119,14 @@ const PreviewWrapper = (props: Props) => {
               </Box>
             )}
 
-            <Flex align="center" style={{flexShrink: 0}}>
+            <Flex align="center" style={{flexShrink: 0, marginLeft: 'auto'}}>
               {/* Avatar */}
               <Box display={['none', 'none', 'block']} marginX={3} style={{flexShrink: 0}}>
                 <User id={schedule?.author} />
               </Box>
 
               {/* Document status */}
-              <Box marginX={[2, 2, 3]} style={{flexShrink: 0}}>
+              <Box display={['none', 'block']} marginX={[2, 2, 3]} style={{flexShrink: 0}}>
                 <Inline space={4}>
                   <PublishedStatus document={previewState?.published} />
                   <DraftStatus document={previewState?.draft} />

--- a/src/components/scheduleItem/PreviewWrapper.tsx
+++ b/src/components/scheduleItem/PreviewWrapper.tsx
@@ -1,5 +1,5 @@
 import {SchemaType} from '@sanity/types'
-import {Box, Card, Flex, Inline, Stack, Text} from '@sanity/ui'
+import {Badge, Box, Card, Flex, Inline, Stack, Text} from '@sanity/ui'
 import {SanityDefaultPreview} from 'part:@sanity/base/preview'
 import React, {ElementType, ReactNode, useState} from 'react'
 import {DOCUMENT_HAS_ERRORS_TEXT, DOCUMENT_HAS_WARNINGS_TEXT} from '../../constants'
@@ -66,7 +66,11 @@ const PreviewWrapper = (props: Props) => {
         >
           <Flex align="center" justify="space-between">
             {children && <Box style={{flexBasis: 'auto', flexGrow: 1}}>{children}</Box>}
-
+            {schedule.action === 'unpublish' ? (
+              <Badge mode="outline" tone="caution" fontSize={0}>
+                Unpublish
+              </Badge>
+            ) : null}
             {/* Schedule date */}
             <>
               <Box

--- a/src/components/scheduleItem/PreviewWrapper.tsx
+++ b/src/components/scheduleItem/PreviewWrapper.tsx
@@ -136,29 +136,31 @@ const PreviewWrapper = (props: Props) => {
           </Flex>
         </Card>
 
-        {/* Validation status (only displayed on upcoming schedules) */}
-        {schedule.state === 'scheduled' && (
-          <Box>
-            <ValidateScheduleDoc schedule={schedule} updateValidation={setValidationStatus} />
-            <ValidationInfo
-              markers={markers}
-              type={schemaType}
-              documentId={publishedDocumentId}
-              menuHeader={
-                <Box padding={2}>
-                  <Text size={1}>
-                    {hasError ? DOCUMENT_HAS_ERRORS_TEXT : DOCUMENT_HAS_WARNINGS_TEXT}
-                  </Text>
-                </Box>
-              }
-            />
-          </Box>
-        )}
+        <Flex justify="center" style={{width: '38px'}}>
+          {/* Validation status (only displayed on upcoming schedules) */}
+          {schedule.state === 'scheduled' && (
+            <Box>
+              <ValidateScheduleDoc schedule={schedule} updateValidation={setValidationStatus} />
+              <ValidationInfo
+                markers={markers}
+                type={schemaType}
+                documentId={publishedDocumentId}
+                menuHeader={
+                  <Box padding={2}>
+                    <Text size={1}>
+                      {hasError ? DOCUMENT_HAS_ERRORS_TEXT : DOCUMENT_HAS_WARNINGS_TEXT}
+                    </Text>
+                  </Box>
+                }
+              />
+            </Box>
+          )}
 
-        {/* Failed state reason (only displayed on cancelled schedules) */}
-        {schedule.state === 'cancelled' && (
-          <StateReasonFailedInfo stateReason={schedule.stateReason} />
-        )}
+          {/* Failed state reason (only displayed on cancelled schedules) */}
+          {schedule.state === 'cancelled' && (
+            <StateReasonFailedInfo stateReason={schedule.stateReason} />
+          )}
+        </Flex>
 
         {/* Context menu */}
         {contextMenu && <Box style={{flexShrink: 0}}>{contextMenu}</Box>}

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,28 +1,44 @@
 import {BadgeTone} from '@sanity/ui'
 import React from 'react'
-import {ScheduleState} from './types'
+import type {ScheduleAction, ScheduleState} from './types'
 
 export const LOCAL_STORAGE_TZ_KEY = 'scheduled-publishing::time-zone'
 
 export const SANITY_API_VERSION = '2022-02-02'
 
+export const SCHEDULE_ACTION_DICTIONARY: Record<
+  ScheduleAction,
+  {
+    actionName: string
+    badgeColor?: 'primary' | 'success' | 'warning' | 'danger' // Document badge specific
+    badgeTone: BadgeTone
+  }
+> = {
+  publish: {
+    actionName: 'Publishing',
+    badgeColor: 'primary',
+    badgeTone: 'positive',
+  },
+  unpublish: {
+    actionName: 'Unpublishing',
+    badgeColor: 'danger',
+    badgeTone: 'critical',
+  },
+}
+
 export const SCHEDULE_STATE_DICTIONARY: Record<
   ScheduleState,
   {
-    badgeTone: BadgeTone
     title: string
   }
 > = {
   scheduled: {
-    badgeTone: 'primary',
     title: 'Upcoming',
   },
   succeeded: {
-    badgeTone: 'default',
     title: 'Completed',
   },
   cancelled: {
-    badgeTone: 'critical',
     title: 'Failed',
   },
 }

--- a/src/documentBadges/scheduled/ScheduledBadge.tsx
+++ b/src/documentBadges/scheduled/ScheduledBadge.tsx
@@ -1,6 +1,6 @@
 import type {DocumentBadgeComponent} from '@sanity/base'
 import {format} from 'date-fns'
-import {DATE_FORMAT} from '../../constants'
+import {DATE_FORMAT, SCHEDULE_ACTION_DICTIONARY} from '../../constants'
 import usePollSchedules from '../../hooks/usePollSchedules'
 import {debugWithName} from '../../utils/debug'
 
@@ -20,8 +20,10 @@ export const ScheduledBadge: DocumentBadgeComponent = (props) => {
   const formattedDateTime = format(new Date(upcomingSchedule.executeAt), DATE_FORMAT.LARGE)
 
   return {
-    color: 'primary',
+    color: SCHEDULE_ACTION_DICTIONARY[upcomingSchedule.action].badgeColor,
     label: `Scheduled`,
-    title: `Publishing on ${formattedDateTime} (local time)`,
+    title: `${
+      SCHEDULE_ACTION_DICTIONARY[upcomingSchedule.action].actionName
+    } on ${formattedDateTime} (local time)`,
   }
 }

--- a/src/hooks/usePollSchedules.ts
+++ b/src/hooks/usePollSchedules.ts
@@ -1,8 +1,9 @@
-import {useCallback, useEffect} from 'react'
+import {useCallback, useEffect, useMemo} from 'react'
 import useSWR from 'swr'
 import {getSanityClient} from '../lib/client'
-import {Schedule, ScheduleState} from '../types'
+import type {Schedule, ScheduleState} from '../types'
 import getScheduleBaseUrl from '../utils/getScheduleBaseUrl'
+import {sortByExecuteDate} from '../utils/sortByExecuteDate'
 import {
   ScheduleDeleteEvent,
   ScheduleDeleteMultipleEvent,
@@ -152,10 +153,16 @@ function usePollSchedules({documentId, state}: {documentId?: string; state?: Sch
     }
   }, [handleDelete, handleDeleteMultiple, handlePublish, handleUpdate])
 
+  // By default: sort schedules by last execute date (executedAt || executeAt)
+  const sortedSchedules = useMemo(
+    () => data?.schedules?.sort(sortByExecuteDate()),
+    [data?.schedules]
+  )
+
   return {
     error,
     isInitialLoading: !error && !data,
-    schedules: data?.schedules || NO_SCHEDULES,
+    schedules: sortedSchedules || NO_SCHEDULES,
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export {ScheduleAction} from './documentActions/schedule'
 export {ScheduledBadge} from './documentBadges/scheduled'
+export {EditScheduleForm} from './components/editScheduleForm/EditScheduleForm'

--- a/src/tool/toolCalendar/CalendarDay.tsx
+++ b/src/tool/toolCalendar/CalendarDay.tsx
@@ -1,11 +1,11 @@
 import {CloseIcon} from '@sanity/icons'
-import type {CardTone} from '@sanity/ui'
+import {CardTone, Inline, Label} from '@sanity/ui'
 import {Badge, Box, Card, Flex, Stack, Text, Tooltip} from '@sanity/ui'
 import {format, isWeekend} from 'date-fns'
 import React, {useCallback, useMemo} from 'react'
-import {SCHEDULE_STATE_DICTIONARY} from '../../constants'
+import {SCHEDULE_ACTION_DICTIONARY, SCHEDULE_STATE_DICTIONARY} from '../../constants'
 import useTimeZone from '../../hooks/useTimeZone'
-import type {Schedule} from '../../types'
+import type {Schedule, ScheduleState} from '../../types'
 import {getLastExecuteDate} from '../../utils/scheduleUtils'
 import {useSchedules} from '../contexts/schedules'
 import Pip from './Pip'
@@ -115,43 +115,79 @@ interface TooltipContentProps {
   schedules?: Schedule[]
 }
 
+type SchedulesByState = Record<ScheduleState, Schedule[]>
+
 function TooltipContent(props: TooltipContentProps) {
   const {date, schedules = []} = props
   const {formatDateTz} = useTimeZone()
 
+  const schedulesByState = schedules.reduce<SchedulesByState>(
+    (acc, val) => {
+      acc[val.state].push(val)
+      return acc
+    },
+    {
+      cancelled: [],
+      succeeded: [],
+      scheduled: [],
+    }
+  )
+
   return (
     <Box padding={3}>
-      <Box marginBottom={3}>
-        <Text muted size={1} weight="regular">
+      <Box marginBottom={4}>
+        <Text size={1} weight="medium">
           {format(date, 'd MMMM yyyy')}
         </Text>
       </Box>
-      <Stack space={2}>
-        {schedules
-          .filter((schedule) => schedule.executeAt)
-          .map((schedule) => {
-            const executeDate = getLastExecuteDate(schedule)
-            if (!executeDate) {
-              return null
-            }
 
-            return (
-              <Flex align="center" gap={3} justify="space-between" key={schedule.id}>
-                <Box>
-                  <Text size={1} weight="semibold">
-                    {formatDateTz({date: new Date(executeDate), format: 'p'})}
-                  </Text>
-                </Box>
-                <Badge
-                  fontSize={0}
-                  mode="outline"
-                  tone={SCHEDULE_STATE_DICTIONARY[schedule.state].badgeTone}
-                >
-                  {SCHEDULE_STATE_DICTIONARY[schedule.state].title}
-                </Badge>
-              </Flex>
-            )
-          })}
+      <Stack space={3}>
+        {(Object.keys(schedulesByState) as Array<keyof typeof schedulesByState>).map((key) => {
+          const stateSchedules = schedulesByState[key]
+          if (stateSchedules.length === 0) {
+            return null
+          }
+          return (
+            <Stack key={key} space={2}>
+              <Label muted size={0}>
+                {SCHEDULE_STATE_DICTIONARY[key].title}
+              </Label>
+              <Stack space={1}>
+                {stateSchedules
+                  .filter((schedule) => schedule.executeAt)
+                  .map((schedule) => {
+                    const executeDate = getLastExecuteDate(schedule)
+                    if (!executeDate) {
+                      return null
+                    }
+
+                    return (
+                      <Inline key={schedule.id} space={2}>
+                        <Box style={{width: '60px'}}>
+                          <Text size={1} weight="regular">
+                            {formatDateTz({date: new Date(executeDate), format: 'p'})}
+                          </Text>
+                        </Box>
+                        {/* HACK: Hide non unpublish schedules to maintain layout */}
+                        <Flex
+                          align="center"
+                          style={{flexShrink: 0, opacity: schedule.action === 'unpublish' ? 1 : 0}}
+                        >
+                          <Badge
+                            fontSize={0}
+                            mode="outline"
+                            tone={SCHEDULE_ACTION_DICTIONARY[schedule.action].badgeTone}
+                          >
+                            {schedule.action}
+                          </Badge>
+                        </Flex>
+                      </Inline>
+                    )
+                  })}
+              </Stack>
+            </Stack>
+          )
+        })}
       </Stack>
     </Box>
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface NormalizedTimeZone {
 
 export interface Schedule {
   author: string
-  action: string
+  action: ScheduleAction
   createdAt: string
   dataset: string
   description: string
@@ -29,6 +29,7 @@ export interface Schedule {
   stateReason: string
 }
 
+export type ScheduleAction = 'publish' | 'unpublish'
 export interface ScheduleFilter {
   state: ScheduleState
   title: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface NormalizedTimeZone {
 
 export interface Schedule {
   author: string
+  action: string
   createdAt: string
   dataset: string
   description: string

--- a/src/utils/sortByExecuteDate.ts
+++ b/src/utils/sortByExecuteDate.ts
@@ -1,0 +1,20 @@
+import type {Schedule} from '../types'
+import {getLastExecuteDate} from './scheduleUtils'
+
+export function sortByExecuteDate({reverseOrder}: {reverseOrder: boolean} = {reverseOrder: false}) {
+  return function (a: Schedule, b: Schedule): number {
+    const aExecuteDate = getLastExecuteDate(a)
+    const bExecuteDate = getLastExecuteDate(b)
+
+    if (aExecuteDate === bExecuteDate) {
+      return 0
+    }
+    if (aExecuteDate === null) {
+      return 1
+    }
+    if (bExecuteDate === null) {
+      return -1
+    }
+    return (aExecuteDate > bExecuteDate ? 1 : -1) * (reverseOrder ? -1 : 1)
+  }
+}


### PR DESCRIPTION
Adds a badge on upcoming Scheduled documents where the `action` is `unpublish`. No change to the UI for upcoming Publish schedules.

<img width="683" alt="Screenshot 2022-09-16 at 16 25 31" src="https://user-images.githubusercontent.com/9684022/190675219-144b1b6d-d879-40e1-adc8-f6e382232493.png">
