### PR TITLE
feat: re-add v2 support for unpublish action badges

### DIFF
--- a/src/components/documentWrapper/ScheduleBanner.tsx
+++ b/src/components/documentWrapper/ScheduleBanner.tsx
@@ -1,77 +1,74 @@
 import {CalendarIcon} from '@sanity/icons'
-import {ValidationMarker, SchemaType} from 'sanity'
-import {Badge, Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {ValidationMarker} from 'sanity'
+import {Badge, Box, Card, Flex, Inline, Stack, Text} from '@sanity/ui'
 import {format} from 'date-fns'
-import React, {useMemo} from 'react'
-import {DATE_FORMAT} from '../../constants'
+import React from 'react'
+import {DATE_FORMAT, DOCUMENT_HAS_ERRORS_TEXT} from '../../constants'
 import usePollSchedules from '../../hooks/usePollSchedules'
 import {usePublishedId} from '../../hooks/usePublishedId'
 import {useValidationState} from '../../utils/validationUtils'
-import {ValidationInfo} from '../validation/ValidationInfo'
 
 interface Props {
   id: string
   markers: ValidationMarker[]
-  type: SchemaType
 }
 
 export function ScheduleBanner(props: Props) {
-  const {id, markers, type} = props
+  const {id, markers} = props
   const publishedId = usePublishedId(id)
   const {hasError} = useValidationState(markers)
-  const formattedDateTime = useNextSchedule(publishedId)
 
-  if (!formattedDateTime) {
+  const {schedules} = usePollSchedules({documentId: publishedId, state: 'scheduled'})
+
+  const hasSchedules = schedules.length > 0
+  if (!hasSchedules) {
     return null
   }
 
   return (
     <Box marginBottom={4}>
-      <Card
-        paddingBottom={2}
-        paddingTop={3}
-        paddingX={3}
-        radius={1}
-        shadow={1}
-        tone={hasError ? 'critical' : 'primary'}
-      >
+      <Card padding={3} radius={1} shadow={1} tone={hasError ? 'critical' : 'primary'}>
         <Stack space={2}>
-          <Flex>
-            <Badge fontSize={1} mode="outline" padding={2} style={{flexShrink: 0}}>
-              {hasError ? 'Scheduled (with errors)' : 'Scheduled'}
-            </Badge>
-          </Flex>
-
-          <Flex align="center" gap={1}>
-            {hasError ? (
-              <ValidationInfo markers={markers} type={type} documentId={publishedId} />
-            ) : (
-              <Box padding={3}>
-                <Text muted>
-                  <CalendarIcon />
-                </Text>
-              </Box>
-            )}
+          <Flex align="center" gap={3} marginBottom={1} padding={1}>
             <Text muted size={1}>
-              {hasError ? 'Publishing with errors on' : 'Scheduled to publish on'}{' '}
-              <span style={{fontWeight: 500}}>{formattedDateTime}</span> (local time)
+              <CalendarIcon />
+            </Text>
+            <Text muted size={1}>
+              <span style={{fontWeight: 600}}>Upcoming schedule</span> (local time)
             </Text>
           </Flex>
+
+          <Stack space={2}>
+            {schedules.map((schedule) => {
+              if (!schedule.executeAt) {
+                return null
+              }
+              const formattedDateTime = format(new Date(schedule.executeAt), DATE_FORMAT.LARGE)
+              return (
+                <Inline key={schedule.id} space={2}>
+                  <Text muted size={1}>
+                    {formattedDateTime}
+                  </Text>
+                  {/* HACK: Hide non unpublish schedules to maintain layout */}
+                  <Flex style={{opacity: schedule.action === 'unpublish' ? 1 : 0}}>
+                    <Badge fontSize={0} mode="outline">
+                      {schedule.action}
+                    </Badge>
+                  </Flex>
+                </Inline>
+              )
+            })}
+          </Stack>
+
+          {hasError && (
+            <Box marginTop={3}>
+              <Text muted size={1} weight="regular">
+                {DOCUMENT_HAS_ERRORS_TEXT}
+              </Text>
+            </Box>
+          )}
         </Stack>
       </Card>
     </Box>
   )
-}
-
-function useNextSchedule(id: string) {
-  const {schedules} = usePollSchedules({documentId: id, state: 'scheduled'})
-
-  return useMemo(() => {
-    const upcomingSchedule = schedules?.[0]
-
-    if (!upcomingSchedule || !upcomingSchedule.executeAt) {
-      return undefined
-    }
-    return format(new Date(upcomingSchedule.executeAt), DATE_FORMAT.LARGE)
-  }, [schedules])
 }

--- a/src/components/documentWrapper/ScheduledDocumentInput.tsx
+++ b/src/components/documentWrapper/ScheduledDocumentInput.tsx
@@ -3,7 +3,7 @@ import {ScheduleBanner} from './ScheduleBanner'
 import {InputProps, ValidationMarker} from 'sanity'
 
 export function ScheduledDocumentInput(props: PropsWithChildren<InputProps>) {
-  const {value, validation, schemaType, children} = props
+  const {value, validation, children} = props
   const doc: {_id?: string} = value as unknown as {_id: string}
 
   const markers: ValidationMarker[] = useMemo(
@@ -18,7 +18,7 @@ export function ScheduledDocumentInput(props: PropsWithChildren<InputProps>) {
 
   return (
     <>
-      {doc?._id ? <ScheduleBanner id={doc._id} markers={markers} type={schemaType} /> : null}
+      {doc?._id ? <ScheduleBanner id={doc._id} markers={markers} /> : null}
       {children}
     </>
   )

--- a/src/components/scheduleItem/PreviewWrapper.tsx
+++ b/src/components/scheduleItem/PreviewWrapper.tsx
@@ -1,7 +1,11 @@
 import {SchemaType, SanityDefaultPreview} from 'sanity'
-import {Box, Card, Flex, Inline, Stack, Text} from '@sanity/ui'
+import {Badge, Box, Card, Flex, Inline, Stack, Text} from '@sanity/ui'
 import React, {ElementType, ReactNode, useState} from 'react'
-import {DOCUMENT_HAS_ERRORS_TEXT, DOCUMENT_HAS_WARNINGS_TEXT} from '../../constants'
+import {
+  DOCUMENT_HAS_ERRORS_TEXT,
+  DOCUMENT_HAS_WARNINGS_TEXT,
+  SCHEDULE_ACTION_DICTIONARY,
+} from '../../constants'
 import useTimeZone from '../../hooks/useTimeZone'
 import {Schedule} from '../../types'
 import {PaneItemPreviewState} from '../../utils/paneItemHelpers'
@@ -63,52 +67,49 @@ const PreviewWrapper = (props: Props) => {
           tabIndex={0}
           tone={validationTone}
         >
-          <Flex align="center" justify="space-between">
+          <Flex align="center" gap={3} justify="flex-start" paddingLeft={children ? 0 : [1, 2]}>
             {children && <Box style={{flexBasis: 'auto', flexGrow: 1}}>{children}</Box>}
 
+            {/* Badge */}
+            {schedule.action === 'unpublish' && (
+              <Flex style={{flexShrink: 0}}>
+                <Badge
+                  fontSize={0}
+                  mode="outline"
+                  tone={SCHEDULE_ACTION_DICTIONARY[schedule.action].badgeTone}
+                >
+                  {schedule.action}
+                </Badge>
+              </Flex>
+            )}
+
             {/* Schedule date */}
-            <>
-              <Box
-                display={['block', 'none']}
-                marginLeft={children ? [3, 3, 4] : 2}
-                style={{
-                  flexShrink: 0,
-                  width: '90px',
-                }}
-              >
-                <Stack space={2}>
-                  {scheduleDate ? (
-                    <>
-                      <Text size={1}>
-                        {formatDateTz({date: scheduleDate, format: 'dd/MM/yyyy'})}
-                      </Text>
-                      <Text size={1}>{formatDateTz({date: scheduleDate, format: 'p'})}</Text>
-                    </>
-                  ) : (
-                    <Text muted size={1}>
-                      <em>No date specified</em>
-                    </Text>
-                  )}
-                </Stack>
-              </Box>
-              <Box
-                display={['none', 'block']}
-                marginLeft={children ? [3, 3, 4] : 2}
-                style={{
-                  flexShrink: 0,
-                  maxWidth: '250px',
-                  width: children ? '35%' : 'auto',
-                }}
-              >
+            <Box display={['block', 'none']} style={{flexShrink: 0, width: '90px'}}>
+              <Stack space={2}>
                 {scheduleDate ? (
-                  <DateWithTooltip date={scheduleDate} useElementQueries={useElementQueries} />
+                  <>
+                    <Text size={1}>{formatDateTz({date: scheduleDate, format: 'dd/MM/yyyy'})}</Text>
+                    <Text size={1}>{formatDateTz({date: scheduleDate, format: 'p'})}</Text>
+                  </>
                 ) : (
                   <Text muted size={1}>
                     <em>No date specified</em>
                   </Text>
                 )}
-              </Box>
-            </>
+              </Stack>
+            </Box>
+            <Box
+              display={['none', 'block']}
+              style={{flexShrink: 0, maxWidth: '250px', width: children ? '35%' : 'auto'}}
+            >
+              {scheduleDate ? (
+                <DateWithTooltip date={scheduleDate} useElementQueries={useElementQueries} />
+              ) : (
+                <Text muted size={1}>
+                  <em>No date specified</em>
+                </Text>
+              )}
+            </Box>
 
             {/* HACK: render invisible preview wrapper when no children are provided to ensure consistent height */}
             {!children && (
@@ -117,14 +118,14 @@ const PreviewWrapper = (props: Props) => {
               </Box>
             )}
 
-            <Flex align="center" style={{flexShrink: 0}}>
+            <Flex align="center" style={{flexShrink: 0, marginLeft: 'auto'}}>
               {/* Avatar */}
               <Box display={['none', 'none', 'block']} marginX={3} style={{flexShrink: 0}}>
                 <User id={schedule?.author} />
               </Box>
 
               {/* Document status */}
-              <Box marginX={[2, 2, 3]} style={{flexShrink: 0}}>
+              <Box display={['none', 'block']} marginX={[2, 2, 3]} style={{flexShrink: 0}}>
                 <Inline space={4}>
                   <PublishedStatus document={previewState?.published} />
                   <DraftStatus document={previewState?.draft} />
@@ -134,24 +135,31 @@ const PreviewWrapper = (props: Props) => {
           </Flex>
         </Card>
 
-        {/* Validation status (only displayed on upcoming schedules) */}
-        {schedule.state === 'scheduled' && (
-          <Box>
-            <ValidateScheduleDoc schedule={schedule} updateValidation={setValidationStatus} />
-            <ValidationInfo
-              markers={validation}
-              type={schemaType}
-              documentId={publishedDocumentId}
-              menuHeader={
-                <Box padding={2}>
-                  <Text size={1}>
-                    {hasError ? DOCUMENT_HAS_ERRORS_TEXT : DOCUMENT_HAS_WARNINGS_TEXT}
-                  </Text>
-                </Box>
-              }
-            />
-          </Box>
-        )}
+        <Flex justify="center" style={{width: '38px'}}>
+          {/* Validation status (only displayed on upcoming schedules) */}
+          {schedule.state === 'scheduled' && (
+            <Box>
+              <ValidateScheduleDoc schedule={schedule} updateValidation={setValidationStatus} />
+              <ValidationInfo
+                markers={validation}
+                type={schemaType}
+                documentId={publishedDocumentId}
+                menuHeader={
+                  <Box padding={2}>
+                    <Text size={1}>
+                      {hasError ? DOCUMENT_HAS_ERRORS_TEXT : DOCUMENT_HAS_WARNINGS_TEXT}
+                    </Text>
+                  </Box>
+                }
+              />
+            </Box>
+          )}
+
+          {/* Failed state reason (only displayed on cancelled schedules) */}
+          {schedule.state === 'cancelled' && (
+            <StateReasonFailedInfo stateReason={schedule.stateReason} />
+          )}
+        </Flex>
 
         {/* Failed state reason (only displayed on cancelled schedules) */}
         {schedule.state === 'cancelled' && (

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,26 +1,42 @@
 import {BadgeTone} from '@sanity/ui'
 import React from 'react'
-import {ScheduleState} from './types'
+import {ScheduleAction, ScheduleState} from './types'
 
 export const LOCAL_STORAGE_TZ_KEY = 'scheduled-publishing::time-zone'
+
+export const SCHEDULE_ACTION_DICTIONARY: Record<
+  ScheduleAction,
+  {
+    actionName: string
+    badgeColor?: 'primary' | 'success' | 'warning' | 'danger' // Document badge specific
+    badgeTone: BadgeTone
+  }
+> = {
+  publish: {
+    actionName: 'Publishing',
+    badgeColor: 'primary',
+    badgeTone: 'positive',
+  },
+  unpublish: {
+    actionName: 'Unpublishing',
+    badgeColor: 'danger',
+    badgeTone: 'critical',
+  },
+}
 
 export const SCHEDULE_STATE_DICTIONARY: Record<
   ScheduleState,
   {
-    badgeTone: BadgeTone
     title: string
   }
 > = {
   scheduled: {
-    badgeTone: 'primary',
     title: 'Upcoming',
   },
   succeeded: {
-    badgeTone: 'default',
     title: 'Completed',
   },
   cancelled: {
-    badgeTone: 'critical',
     title: 'Failed',
   },
 }

--- a/src/documentBadges/scheduled/ScheduledBadge.tsx
+++ b/src/documentBadges/scheduled/ScheduledBadge.tsx
@@ -1,6 +1,6 @@
 import type {DocumentBadgeComponent} from 'sanity'
 import {format} from 'date-fns'
-import {DATE_FORMAT} from '../../constants'
+import {DATE_FORMAT, SCHEDULE_ACTION_DICTIONARY} from '../../constants'
 import usePollSchedules from '../../hooks/usePollSchedules'
 import {debugWithName} from '../../utils/debug'
 
@@ -20,8 +20,10 @@ export const ScheduledBadge: DocumentBadgeComponent = (props) => {
   const formattedDateTime = format(new Date(upcomingSchedule.executeAt), DATE_FORMAT.LARGE)
 
   return {
-    color: 'primary',
+    color: SCHEDULE_ACTION_DICTIONARY[upcomingSchedule.action].badgeColor,
     label: `Scheduled`,
-    title: `Publishing on ${formattedDateTime} (local time)`,
+    title: `${
+      SCHEDULE_ACTION_DICTIONARY[upcomingSchedule.action].actionName
+    } on ${formattedDateTime} (local time)`,
   }
 }

--- a/src/hooks/usePollSchedules.ts
+++ b/src/hooks/usePollSchedules.ts
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useMemo} from 'react'
 import useSWR from 'swr'
 import {Schedule, ScheduleState} from '../types'
+import {sortByExecuteDate} from '../utils/sortByExecuteDate'
 import {
   ScheduleDeleteEvent,
   ScheduleDeleteMultipleEvent,
@@ -163,10 +164,16 @@ function usePollSchedules({documentId, state}: {documentId?: string; state?: Sch
     }
   }, [handleDelete, handleDeleteMultiple, handlePublish, handleUpdate])
 
+  // By default: sort schedules by last execute date (executedAt || executeAt)
+  const sortedSchedules = useMemo(
+    () => data?.schedules?.sort(sortByExecuteDate()),
+    [data?.schedules]
+  )
+
   return {
     error,
     isInitialLoading: !error && !data,
-    schedules: data?.schedules || NO_SCHEDULES,
+    schedules: sortedSchedules || NO_SCHEDULES,
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {DocumentBannerInput} from './inputResolver'
 
 export {ScheduleAction} from './documentActions/schedule'
 export {ScheduledBadge} from './documentBadges/scheduled'
+export {EditScheduleForm} from './components/editScheduleForm/EditScheduleForm'
 export {resolveDocumentActions, resolveDocumentBadges}
 
 export const scheduledPublishing = definePlugin({

--- a/src/tool/contexts/schedules.tsx
+++ b/src/tool/contexts/schedules.tsx
@@ -3,6 +3,7 @@ import React, {createContext, ReactNode, useCallback, useContext, useMemo, useSt
 import useTimeZone from '../../hooks/useTimeZone'
 import {Schedule, ScheduleSort, ScheduleState} from '../../types'
 import {getLastExecuteDate} from '../../utils/scheduleUtils'
+import {sortByExecuteDate} from '../../utils/sortByExecuteDate'
 
 type State = {
   activeSchedules: Schedule[]
@@ -82,20 +83,8 @@ function SchedulesProvider({
             return a[sortBy] < b[sortBy] ? 1 : -1
           }
           if (sortBy === 'executeAt') {
-            const invertOrder = value.scheduleState === 'scheduled' || value.selectedDate ? -1 : 1
-            const aExecuteDate = getLastExecuteDate(a)
-            const bExecuteDate = getLastExecuteDate(b)
-
-            if (aExecuteDate === bExecuteDate) {
-              return 0
-            }
-            if (aExecuteDate === null) {
-              return 1
-            }
-            if (bExecuteDate === null) {
-              return -1
-            }
-            return (aExecuteDate > bExecuteDate ? -1 : 1) * invertOrder
+            const reverseOrder = !(value.scheduleState === 'scheduled' || value.selectedDate)
+            return sortByExecuteDate({reverseOrder})(a, b)
           }
           return 1
         }) || []
@@ -119,21 +108,9 @@ function SchedulesProvider({
    */
   const schedulesByDate = useCallback(
     (wallDate: Date) => {
-      return value.schedules.filter(filterByDate(wallDate)).sort((a, b) => {
-        const aExecuteDate = getLastExecuteDate(a)
-        const bExecuteDate = getLastExecuteDate(b)
-
-        if (aExecuteDate === bExecuteDate) {
-          return 0
-        }
-        if (aExecuteDate === null) {
-          return 1
-        }
-        if (bExecuteDate === null) {
-          return -1
-        }
-        return aExecuteDate > bExecuteDate ? 1 : -1
-      })
+      return value.schedules
+        .filter(filterByDate(wallDate)) //
+        .sort(sortByExecuteDate())
     },
     [value.schedules, filterByDate]
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface NormalizedTimeZone {
 
 export interface Schedule {
   author: string
+  action: ScheduleAction
   createdAt: string
   dataset: string
   description: string
@@ -27,6 +28,8 @@ export interface Schedule {
   state: ScheduleState
   stateReason: string
 }
+
+export type ScheduleAction = 'publish' | 'unpublish'
 
 export interface ScheduleFilter {
   state: ScheduleState

--- a/src/utils/sortByExecuteDate.ts
+++ b/src/utils/sortByExecuteDate.ts
@@ -1,0 +1,20 @@
+import type {Schedule} from '../types'
+import {getLastExecuteDate} from './scheduleUtils'
+
+export function sortByExecuteDate({reverseOrder}: {reverseOrder: boolean} = {reverseOrder: false}) {
+  return function (a: Schedule, b: Schedule): number {
+    const aExecuteDate = getLastExecuteDate(a)
+    const bExecuteDate = getLastExecuteDate(b)
+
+    if (aExecuteDate === bExecuteDate) {
+      return 0
+    }
+    if (aExecuteDate === null) {
+      return 1
+    }
+    if (bExecuteDate === null) {
+      return -1
+    }
+    return (aExecuteDate > bExecuteDate ? 1 : -1) * (reverseOrder ? -1 : 1)
+  }
+}


### PR DESCRIPTION
This PR reinstates [some changes made](https://github.com/sanity-io/sanity-plugin-scheduled-publishing/pull/16) to the v2 plugin to support display of badges for scheduled unpublishing of documents.