### PR TITLE
feat: export `Schedule`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {ScheduleAction} from './documentActions/schedule'
 export {ScheduledBadge} from './documentBadges/scheduled'
 export {EditScheduleForm} from './components/editScheduleForm/EditScheduleForm'
 export {resolveDocumentActions, resolveDocumentBadges}
+export type {Schedule} from './types'
 
 export const scheduledPublishing = definePlugin({
   name: 'scheduled-publishing',


### PR DESCRIPTION
I'm customizing the desk structure of a Studio to show scheduled documents. It would be helpful to have the `Schedule` interface to import:
```ts
import type {Schedule} from '@sanity/scheduled-publishing'

S.listItem({
  id: 'scheduled',
  title: 'Scheduled',
  icon: CalendarIcon,
  // ...rest of the spec
  child: from(
    client.request({
      uri: `/schedules/${projectId}/${dataset}`,
      query: {
        state: 'scheduled',
      },
    })
  ).pipe(
    map<any, Schedule[]>((response) => response.schedules),
    // ...rest of the pipeline
  ),
})
```