### PR TITLE
chore: add auto npm deprecate workflow

### DIFF
--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -17,4 +17,5 @@ jobs:
         with:
           node-version: lts/*
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_DEPRECATE_TOKEN }}" > ~/.npmrc
-      - run: npm deprecate "@sanity/scheduled-publishing@1.x" "As of v3.39.0 of Sanity Studio, this plugin has been deprecated and the Scheduled Publishing functionality has been moved into the core studio package. Read more and learn how to update your configuration in the Sanity docs: https://www.sanity.io/docs/scheduled-publishing" || true
+      - run: >
+          npm deprecate "@sanity/scheduled-publishing@1.x" "As of v3.39.0 of Sanity Studio, this plugin has been deprecated and the Scheduled Publishing functionality has been moved into the core studio package. Read more and learn how to update your configuration in the Sanity docs: https://www.sanity.io/docs/scheduled-publishing" || true

--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -1,0 +1,20 @@
+---
+name: Deprecate package on npm
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read # for checkout
+
+jobs:
+  deprecate-overlays:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_DEPRECATE_TOKEN }}" > ~/.npmrc
+      - run: npm deprecate "@sanity/scheduled-publishing@1.x" "As of v3.39.0 of Sanity Studio, this plugin has been deprecated and the Scheduled Publishing functionality has been moved into the core studio package. Read more and learn how to update your configuration in the Sanity docs: https://www.sanity.io/docs/scheduled-publishing" || true


### PR DESCRIPTION
I've set the message to match the readme notice, and only affect the stable v1 range as I understand versions older than v1 is for Studio v2?